### PR TITLE
Add Polly's tweets and gits of hub

### DIFF
--- a/_data/organizers.yml
+++ b/_data/organizers.yml
@@ -24,4 +24,6 @@
   title: Organizer
   pronouns: she/her
   about: "Serial good conference organizer: WeCamp, Python for Good, and now Ruby by the Bay!"
+  twitter: N3rdyTeacher
+  github: pollygee
   img: assets/img/gallery/polly_thumbnail.jpg


### PR DESCRIPTION
Right now, clicking on her social-media icons go to the home pages for those social medias.