### PR TITLE
Fix "Organizers" layout: Displays correctly & independent of number of people

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,3 +1,9 @@
+.flex-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 .navigation-bar-header-spacer {
   height: 50px;
 }
@@ -167,4 +173,3 @@ color: #e96958;
   box-shadow: 0 0 5px 3px rgba(0,0,0,0.15);
   border: thin dashed white;
 }
-

--- a/assets/css/style-2018.css
+++ b/assets/css/style-2018.css
@@ -504,6 +504,8 @@ label.error { display: block; }
   font-size: 18px; }
 #speakers .social-link a:Hover { opacity: 1; color:#e96958; border-color:#e96958; }
 
+#organizer-header { margin-bottom: 10rem; }
+
 .pricing-cols { margin-top: 30px; width: 100%; display: inline-block; border-collapse: collapse; margin-bottom: -20px; }
 .pricing-col {
   float: left;

--- a/index.html
+++ b/index.html
@@ -292,27 +292,27 @@ layout: base
     <div class="overlay"></div>
     <div class="container">
         <div class="icon-wrap"><span class="icon icon-active icon-badges-votes-13"></span></div>
-        <h3>Our Organizers</h3>
-        <br/>
-        <br/>
+        <h3 id="organizer-header">Our Organizers</h3>
         <section class="row">
-            {% for person in site.data.organizers %}
-            <div class="col-sm-6 col-sm-6 col-sm-6 col-sm-6 col-sm-6">
-                <div class="speaker-item animated hiding" data-animation="fadeInUp" data-delay="0">
-                    <div class="img-wrapper">
-                        <img src="{{ person.img }}" class="img-speaker img-responsive img-circle"/>
+            <div class="flex-container">
+                {% for person in site.data.organizers %}
+                    <div class="col-sm-6">
+                        <div class="speaker-item animated hiding" data-animation="fadeInUp" data-delay="0">
+                            <div class="img-wrapper">
+                                <img src="{{ person.img }}" class="img-speaker img-responsive img-circle"/>
+                            </div>
+                            <div class="name">{{ person.name }}</div>
+                            <div class="small">{{ person.pronouns }}</div>
+                            <div class="sub">{{ person.title }}</div>
+                            <p class="small">{{ person.about }}</p>
+                            <div class="social-link">
+                                <a href="https://twitter.com/{{ person.twitter }}"><span class="fa fa-twitter"></span></a>
+                                <a href="https://github.com/{{ person.github }}"><span class="fa fa-github"></span></a>
+                            </div>
+                        </div>
                     </div>
-                    <div class="name">{{ person.name }}</div>
-                    <div class="small">{{ person.pronouns }}</div>
-                    <div class="sub">{{ person.title }}</div>
-                    <p class="small">{{ person.about }}</p>
-                    <div class="social-link">
-                        <a href="https://twitter.com/{{ person.twitter }}"><span class="fa fa-twitter"></span></a>
-                        <a href="https://github.com/{{ person.github }}"><span class="fa fa-github"></span></a>
-                    </div>
-                </div>
+                {% endfor %}
             </div>
-            {% endfor %}
         </section>
         <!--
         <div class="btn-wrapper">


### PR DESCRIPTION
- Fixes the shifted organizers starting on the second row, ie. currently Kara is on the right, Polly on a third row - everyone will line up correctly now
- Added a flexbox container to handle odd numbers of organizers and keep centering/responsiveness for the future
- Setup to easily adjust how many organizers there are per row later - currently 2, but if you wanted 4, change the `col-6` class, line 299,  to`col-3` instead of `col-6`
- Centered people around the background "bars" for prettiness